### PR TITLE
✨ Expose input string from EntitySelectors

### DIFF
--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/arguments/selector/EntitySelector.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/arguments/selector/EntitySelector.java
@@ -34,14 +34,18 @@ import java.util.List;
  */
 public abstract class EntitySelector {
 
+    private final String selector;
     private final List<Entity> entities;
 
     /**
      * Construct a new entity selector
      *
+     * @param selector The input string used to create this selector
      * @param entities The List of Bukkit {@link Entity entities} to construct the {@link EntitySelector} from
      */
-    public EntitySelector(final @NonNull List<@NonNull Entity> entities) {
+    public EntitySelector(final @NonNull String selector,
+                          final @NonNull List<@NonNull Entity> entities) {
+        this.selector = selector;
         this.entities = entities;
     }
 
@@ -54,4 +58,12 @@ public abstract class EntitySelector {
         return Collections.unmodifiableList(this.entities);
     }
 
+    /**
+     * Get the input String for this selector
+     *
+     * @return The input String for this selector
+     */
+    public @NonNull String getSelector() {
+        return this.selector;
+    }
 }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/arguments/selector/MultipleEntitySelector.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/arguments/selector/MultipleEntitySelector.java
@@ -31,10 +31,12 @@ import java.util.List;
 public class MultipleEntitySelector extends EntitySelector {
 
     /**
+     * @param selector The input string used to create this selector
      * @param entities The List of Bukkit {@link Entity}s to construct the {@link EntitySelector} from
      */
-    public MultipleEntitySelector(final @NonNull List<@NonNull Entity> entities) {
-        super(entities);
+    public MultipleEntitySelector(final @NonNull String selector,
+                                  final @NonNull List<@NonNull Entity> entities) {
+        super(selector, entities);
     }
 
 }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/arguments/selector/MultiplePlayerSelector.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/arguments/selector/MultiplePlayerSelector.java
@@ -39,10 +39,12 @@ public class MultiplePlayerSelector extends MultipleEntitySelector {
     /**
      * Construct a new selector
      *
+     * @param selector The input string used to create this selector
      * @param entities The List of Bukkit {@link Entity}s to construct the {@link EntitySelector} from
      */
-    public MultiplePlayerSelector(final @NonNull List<@NonNull Entity> entities) {
-        super(entities);
+    public MultiplePlayerSelector(final @NonNull String selector,
+                                  final @NonNull List<@NonNull Entity> entities) {
+        super(selector, entities);
         entities.forEach(e -> {
             if (e.getType() != EntityType.PLAYER) {
                 throw new IllegalArgumentException("Non-players selected in player selector.");

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/arguments/selector/SingleEntitySelector.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/arguments/selector/SingleEntitySelector.java
@@ -33,10 +33,12 @@ public final class SingleEntitySelector extends MultipleEntitySelector {
     /**
      * Construct a new selector
      *
+     * @param selector The input string used to create this selector
      * @param entities The List of Bukkit {@link Entity entities} to construct the {@link EntitySelector} from
      */
-    public SingleEntitySelector(final @NonNull List<@NonNull Entity> entities) {
-        super(entities);
+    public SingleEntitySelector(final @NonNull String selector,
+                                final @NonNull List<@NonNull Entity> entities) {
+        super(selector, entities);
         if (entities.size() > 1) {
             throw new IllegalArgumentException("More than 1 entity selected in single entity selector.");
         }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/arguments/selector/SinglePlayerSelector.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/arguments/selector/SinglePlayerSelector.java
@@ -34,10 +34,12 @@ public final class SinglePlayerSelector extends MultiplePlayerSelector {
     /**
      * Construct a new selector
      *
+     * @param selector The input string used to create this selector
      * @param entities The List of Bukkit {@link Entity entities} to construct the {@link EntitySelector} from
      */
-    public SinglePlayerSelector(final @NonNull List<@NonNull Entity> entities) {
-        super(entities);
+    public SinglePlayerSelector(final @NonNull String selector,
+                                final @NonNull List<@NonNull Entity> entities) {
+        super(selector, entities);
         if (getPlayers().size() > 1) {
             throw new IllegalArgumentException("More than 1 player selected in single player selector.");
         }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultipleEntitySelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultipleEntitySelectorArgument.java
@@ -140,7 +140,7 @@ public final class MultipleEntitySelectorArgument<C> extends CommandArgument<C, 
                 return ArgumentParseResult.failure(new SelectorParseException(input));
             }
 
-            return ArgumentParseResult.success(new MultipleEntitySelector(entities));
+            return ArgumentParseResult.success(new MultipleEntitySelector(input, entities));
         }
     }
 

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultiplePlayerSelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultiplePlayerSelectorArgument.java
@@ -140,7 +140,7 @@ public final class MultiplePlayerSelectorArgument<C> extends CommandArgument<C, 
                 if (player == null) {
                     return ArgumentParseResult.failure(new PlayerArgument.PlayerParseException(input));
                 }
-                return ArgumentParseResult.success(new MultiplePlayerSelector(ImmutableList.of(player)));
+                return ArgumentParseResult.success(new MultiplePlayerSelector(input, ImmutableList.of(player)));
             }
 
             List<Entity> entities;
@@ -156,7 +156,7 @@ public final class MultiplePlayerSelectorArgument<C> extends CommandArgument<C, 
                 }
             }
 
-            return ArgumentParseResult.success(new MultiplePlayerSelector(entities));
+            return ArgumentParseResult.success(new MultiplePlayerSelector(input, entities));
         }
 
         @Override

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SingleEntitySelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SingleEntitySelectorArgument.java
@@ -144,7 +144,7 @@ public final class SingleEntitySelectorArgument<C> extends CommandArgument<C, Si
                         new IllegalArgumentException("More than 1 entity selected in single entity selector."));
             }
 
-            return ArgumentParseResult.success(new SingleEntitySelector(entities));
+            return ArgumentParseResult.success(new SingleEntitySelector(input, entities));
         }
     }
 

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SinglePlayerSelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SinglePlayerSelectorArgument.java
@@ -139,7 +139,7 @@ public final class SinglePlayerSelectorArgument<C> extends CommandArgument<C, Si
                 if (player == null) {
                     return ArgumentParseResult.failure(new PlayerArgument.PlayerParseException(input));
                 }
-                return ArgumentParseResult.success(new SinglePlayerSelector(ImmutableList.of(player)));
+                return ArgumentParseResult.success(new SinglePlayerSelector(input, ImmutableList.of(player)));
             }
 
             List<Entity> entities;
@@ -159,7 +159,7 @@ public final class SinglePlayerSelectorArgument<C> extends CommandArgument<C, Si
                         new IllegalArgumentException("More than 1 player selected in single player selector"));
             }
 
-            return ArgumentParseResult.success(new SinglePlayerSelector(entities));
+            return ArgumentParseResult.success(new SinglePlayerSelector(input, entities));
         }
 
         @Override


### PR DESCRIPTION
This is useful for providing more verbose feedback in certain situations, like informing the user something like ``Error: No entites found using selector '@whatever'`` when we get an empty collection, instead of just ``Error: No entities found using selector``