### PR TITLE
Make an Exception get thrown when AsyncTabCompleteEvent isn't present

### DIFF
--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperCommandManager.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperCommandManager.java
@@ -85,8 +85,11 @@ public class PaperCommandManager<C> extends BukkitCommandManager<C> {
     /**
      * Register asynchronous completions. This requires all argument parsers to be thread safe, and it
      * is up to the caller to guarantee that such is the case
+     *
+     * @throws ClassNotFoundException When Async completions are not supported by the server
      */
-    public void registerAsynchronousCompletions() {
+    public void registerAsynchronousCompletions() throws ClassNotFoundException {
+        Class.forName("com.destroystokyo.paper.event.server.AsyncTabCompleteEvent");
         Bukkit.getServer().getPluginManager().registerEvents(new AsyncCommandSuggestionsListener<>(this), this.getOwningPlugin());
     }
 


### PR DESCRIPTION
When trying to register the async tab complete listener, manually check for the presence of ``AsyncTabCompleteEvent`` before registering. This allows for your own exception handling, instead of letting Bukkit handle it. This is desirable as Bukkit catches the exception logging an error in the console, without re-throwing the exception or giving any way to intercept the message.