### PR TITLE
✨ Throw an IllegalStateException when trying to register async completions on an unsupported server

### DIFF
--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperCommandManager.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperCommandManager.java
@@ -85,8 +85,13 @@ public class PaperCommandManager<C> extends BukkitCommandManager<C> {
     /**
      * Register asynchronous completions. This requires all argument parsers to be thread safe, and it
      * is up to the caller to guarantee that such is the case
+     *
+     * @throws IllegalStateException when the server does not support asynchronous completions.
      */
-    public void registerAsynchronousCompletions() {
+    public void registerAsynchronousCompletions() throws IllegalStateException {
+        if (!this.queryCapability(CloudBukkitCapabilities.ASYNCHRONOUS_COMPLETION)) {
+            throw new IllegalStateException("Failed to register asynchronous command completion listener.");
+        }
         Bukkit.getServer().getPluginManager().registerEvents(new AsyncCommandSuggestionsListener<>(this), this.getOwningPlugin());
     }
 


### PR DESCRIPTION
Allows for developers to decide whether they want to fail silently, inform the user, or something else.