### PR TITLE
Small fixes

### DIFF
--- a/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
@@ -285,7 +285,7 @@ public abstract class CommandManager<C> {
             final @NonNull Description description,
             final @NonNull CommandMeta meta
     ) {
-        return Command.newBuilder(name, meta, description, aliases.toArray(new String[0]));
+        return Command.<C>newBuilder(name, meta, description, aliases.toArray(new String[0])).manager(this);
     }
 
     /**
@@ -301,7 +301,7 @@ public abstract class CommandManager<C> {
             final @NonNull Collection<String> aliases,
             final @NonNull CommandMeta meta
     ) {
-        return Command.newBuilder(name, meta, Description.empty(), aliases.toArray(new String[0]));
+        return Command.<C>newBuilder(name, meta, Description.empty(), aliases.toArray(new String[0])).manager(this);
     }
 
     /**
@@ -319,7 +319,7 @@ public abstract class CommandManager<C> {
             final @NonNull Description description,
             final @NonNull String... aliases
     ) {
-        return Command.newBuilder(name, meta, description, aliases);
+        return Command.<C>newBuilder(name, meta, description, aliases).manager(this);
     }
 
     /**
@@ -335,7 +335,7 @@ public abstract class CommandManager<C> {
             final @NonNull CommandMeta meta,
             final @NonNull String... aliases
     ) {
-        return Command.newBuilder(name, meta, Description.empty(), aliases);
+        return Command.<C>newBuilder(name, meta, Description.empty(), aliases).manager(this);
     }
 
     /**

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/parser/StandardParserRegistry.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/parser/StandardParserRegistry.java
@@ -83,6 +83,7 @@ public final class StandardParserRegistry<C> implements ParserRegistry<C> {
         /* Register standard mappers */
         this.<Range, Number>registerAnnotationMapper(Range.class, new RangeMapper<>());
         this.<Completions, String>registerAnnotationMapper(Completions.class, new CompletionsMapper());
+        this.<Greedy, String>registerAnnotationMapper(Greedy.class, new GreedyMapper());
 
         /* Register standard types */
         this.registerParserSupplier(TypeToken.get(Byte.class), options ->

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitPluginRegistrationHandler.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitPluginRegistrationHandler.java
@@ -76,17 +76,7 @@ public class BukkitPluginRegistrationHandler<C> implements CommandRegistrationHa
                 && this.registeredCommands.containsKey(commandArgument)) {
             return false;
         }
-
-        final String label;
-        final String prefixedLabel = String.format("%s:%s", this.bukkitCommandManager.getOwningPlugin().getName(),
-                commandArgument.getName()
-        ).toLowerCase();
-        if (!(this.bukkitCommandManager.getCommandRegistrationHandler() instanceof CloudCommodoreManager)
-                && bukkitCommands.containsKey(commandArgument.getName())) {
-            label = prefixedLabel;
-        } else {
-            label = commandArgument.getName();
-        }
+        final String label = commandArgument.getName();
 
         @SuppressWarnings("unchecked")
         final List<String> aliases = new ArrayList<>(((StaticArgument<C>) commandArgument).getAlternativeAliases());

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitPluginRegistrationHandler.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitPluginRegistrationHandler.java
@@ -91,10 +91,6 @@ public class BukkitPluginRegistrationHandler<C> implements CommandRegistrationHa
         @SuppressWarnings("unchecked")
         final List<String> aliases = new ArrayList<>(((StaticArgument<C>) commandArgument).getAlternativeAliases());
 
-        if (!label.contains(":")) {
-            aliases.add(prefixedLabel);
-        }
-
         @SuppressWarnings("unchecked") final BukkitCommand<C> bukkitCommand = new BukkitCommand<>(
                 label,
                 (this.bukkitCommandManager.getSplitAliases() ? Collections.<String>emptyList() : aliases),


### PR DESCRIPTION
Fixes commands getting registered double namespaced, i.e. ``/plugin:plugin:command`` when using the Bukkit platforms without Brigadier.
Also registers the annotation mapper for ``@Greedy``